### PR TITLE
Allow external psql database support

### DIFF
--- a/charts/kutt/templates/deployment.yaml
+++ b/charts/kutt/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
                   key: {{ include "postgresql.userPasswordKey" .Subcharts.postgresql }}
             - name: DB_SSL
               value: "false"
-            {{- else if xx.Values.postgresql.auth.hostname }}
+            {{- else if .Values.postgresql.auth.hostname }}
             - name: DB_HOST
               value: {{ .Values.postgresql.auth.hostname }}
             - name: DB_PORT

--- a/charts/kutt/templates/deployment.yaml
+++ b/charts/kutt/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
                   key: {{ include "postgresql.userPasswordKey" .Subcharts.postgresql }}
             - name: DB_SSL
               value: "false"
-            {{- else }}
+            {{- else if ne .Values.postgresql.auth.hostname "" }}
             - name: DB_HOST
               value: {{ .Values.postgresql.auth.hostname }}
             - name: DB_PORT

--- a/charts/kutt/templates/deployment.yaml
+++ b/charts/kutt/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
                   key: {{ include "postgresql.userPasswordKey" .Subcharts.postgresql }}
             - name: DB_SSL
               value: "false"
-            {{- else if ne .Values.postgresql.auth.hostname "" }}
+            {{- else if xx.Values.postgresql.auth.hostname }}
             - name: DB_HOST
               value: {{ .Values.postgresql.auth.hostname }}
             - name: DB_PORT

--- a/charts/kutt/templates/deployment.yaml
+++ b/charts/kutt/templates/deployment.yaml
@@ -106,6 +106,24 @@ spec:
                   key: {{ include "postgresql.userPasswordKey" .Subcharts.postgresql }}
             - name: DB_SSL
               value: "false"
+            {{- else }}
+            - name: DB_HOST
+              value: {{ .Values.postgresql.auth.hostname }}
+            - name: DB_PORT
+              value: {{ .Values.postgresql.auth.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.postgresql.auth.database }}
+            - name: DB_USER
+              value: {{ .Values.postgresql.auth.username }}
+            - name: DB_PASSWORD
+              {{- if .Values.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: db_password
+              {{- else }}
+              value: {{ .Values.postgresql.auth.password }}
+              {{- end }}
             {{- end }}
             # Redis Settings
             {{- if .Values.redis.enabled }}

--- a/charts/kutt/values.schema.json
+++ b/charts/kutt/values.schema.json
@@ -189,6 +189,12 @@
                 "auth": {
                     "type": "object",
                     "properties": {
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
                         "database": {
                             "type": "string"
                         },

--- a/charts/kutt/values.schema.json
+++ b/charts/kutt/values.schema.json
@@ -203,6 +203,9 @@
                         },
                         "username": {
                             "type": "string"
+                        },
+                        "existingSecret": {
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/kutt/values.yaml
+++ b/charts/kutt/values.yaml
@@ -75,9 +75,9 @@ postgresql:
     username: kutt
     # @param postgresql.auth.hostname External PostgreSQL database hostname
     hostname: ""
-    # @param postgresql.auth.hostname External PostgreSQL database port
+    # @param postgresql.auth.port External PostgreSQL database port
     port: 5432
-    # @param postgresql.auth.hostname External PostgreSQL database secrets. The secret has to contain the key `db_password`
+    # @param postgresql.auth.existingSecret External PostgreSQL database secrets. The secret has to contain the key `db_password`
     existingSecret: ""
 
 redis:

--- a/charts/kutt/values.yaml
+++ b/charts/kutt/values.yaml
@@ -73,6 +73,12 @@ postgresql:
     database: kutt
     password: kutt
     username: kutt
+    # @param postgresql.auth.hostname External PostgreSQL database hostname
+    hostname: ""
+    # @param postgresql.auth.hostname External PostgreSQL database port
+    port: 5432
+    # @param postgresql.auth.hostname External PostgreSQL database secrets. The secret has to contain the key `db_password`
+    existingSecret: ""
 
 redis:
   enabled: true


### PR DESCRIPTION
At present chart does not allow to easily use external database - it requires overwriting of $ENV variables.

This feature adds support for external PostgreSQL database.