### PR TITLE
fix: kutt probes path

### DIFF
--- a/.github/config/datree.yaml
+++ b/.github/config/datree.yaml
@@ -162,4 +162,3 @@ policies:
       #   messageOnFailure: Missing property object `requests.cpu` - value should be within the accepted boundaries recommended by the organization
       # - identifier: CONTAINERS_MISSING_CPU_LIMIT_KEY
       #   messageOnFailure: Missing property object `limits.cpu` - value should be within the accepted boundaries recommended by the organization
-

--- a/.github/workflows/datree.yaml
+++ b/.github/workflows/datree.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  DATREE_TOKEN: ${{ secrets.DATREE_TOKEN }} 
+  DATREE_TOKEN: ${{ secrets.DATREE_TOKEN }}
 
 jobs:
   k8sPolicyCheck:

--- a/.github/workflows/datree.yaml
+++ b/.github/workflows/datree.yaml
@@ -8,7 +8,7 @@ on:
     branches: [main]
     paths: ["charts/**"]
   workflow_dispatch:
-    
+
 env:
   DATREE_TOKEN: ${{ secrets.DATREE_TOKEN }} 
 
@@ -24,35 +24,35 @@ jobs:
 
       - name: Update dependencies
         run: find charts/ ! -path charts/ -maxdepth 1 -type d -exec helm dependency update {} \;
-        
+
       - name: Run Datree Policy Check for k8s v1.21.0
         uses: datreeio/action-datree@main
         with:
           path: 'charts'
           cliArguments: '--only-k8s-files --policy-config .github/config/datree.yaml --schema-version 1.21.0'
           isHelmChart: true
-        
+
       - name: Run Datree Policy Check for k8s v1.22.0
         uses: datreeio/action-datree@main
         with:
           path: 'charts'
           cliArguments: '--only-k8s-files --policy-config .github/config/datree.yaml --schema-version 1.22.0'
           isHelmChart: true
-        
+
       - name: Run Datree Policy Check for k8s v1.23.0
         uses: datreeio/action-datree@main
         with:
           path: 'charts'
           cliArguments: '--only-k8s-files --policy-config .github/config/datree.yaml --schema-version 1.23.0'
           isHelmChart: true
-        
+
       - name: Run Datree Policy Check for k8s v1.24.0
         uses: datreeio/action-datree@main
         with:
           path: 'charts'
           cliArguments: '--only-k8s-files --policy-config .github/config/datree.yaml --schema-version 1.24.0'
           isHelmChart: true
-        
+
       - name: Run Datree Policy Check for k8s v1.25.0
         uses: datreeio/action-datree@main
         with:

--- a/charts/kutt/Chart.yaml
+++ b/charts/kutt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kutt
 description: Kutt is a free modern URL shortener.
 type: application
-version: 1.1.9
+version: 1.1.10
 appVersion: "v2.7.4"
 home: https://github.com/christianknell/helm-charts
 icon: https://www.saashub.com/images/app/service_logos/15/d634f2359578/large.png

--- a/charts/kutt/templates/deployment.yaml
+++ b/charts/kutt/templates/deployment.yaml
@@ -129,11 +129,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/v2/health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/v2/health
               port: http
           {{- with .Values.resources }}
           resources:


### PR DESCRIPTION
Hi ! 

I was installing Kutt with your Helm chart and came across some warnings on the probes making requests on the `/` path. I found out that you could use this kutt API instead : https://docs.kutt.it/#tag/health

Best Regards