### PR TITLE
Fix missing password env secrets for celery workers in Baserow

### DIFF
--- a/charts/baserow/templates/celery-deployment.yaml
+++ b/charts/baserow/templates/celery-deployment.yaml
@@ -56,6 +56,25 @@ spec:
                   name: {{ include "baserow.backend.email.secretName" . | quote }}
                   key: email-password
             {{- end }}
+            # Baserow File Upload Settings
+            { { - if or .Values.backend.config.aws.accessKeyId .Values.backend.config.aws.existingSecret } }
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.backend.aws.secretName" . | quote } }
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.backend.aws.secretName" . | quote } }
+                  key: secret-access-key
+            { { - end } }
+            # Database Settings
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.postgresql.secretName" . | quote } }
+                  key: { { include "baserow.postgresql.userPasswordKey" . | quote } }
             # Redis Settings
             {{- if eq (include "baserow.redis.auth.enabled" .) "true" }}
             - name: REDIS_PASSWORD
@@ -123,6 +142,33 @@ spec:
                 secretKeyRef:
                   name: {{ include "baserow.backend.secretName" . | quote }}
                   key: secret-key
+            # Baserow Email Settings
+            { { - if .Values.backend.config.email.smtp } }
+            - name: EMAIL_SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.backend.email.secretName" . | quote } }
+                  key: email-password
+            { { - end } }
+            # Baserow File Upload Settings
+            { { - if or .Values.backend.config.aws.accessKeyId .Values.backend.config.aws.existingSecret } }
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.backend.aws.secretName" . | quote } }
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.backend.aws.secretName" . | quote } }
+                  key: secret-access-key
+            { { - end } }
+            # Database Settings
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: { { include "baserow.postgresql.secretName" . | quote } }
+                  key: { { include "baserow.postgresql.userPasswordKey" . | quote } }
             # Redis Settings
             {{- if eq (include "baserow.redis.auth.enabled" .) "true" }}
             - name: REDIS_PASSWORD


### PR DESCRIPTION
Currently if using the DATABASE_PASSWORD env var to access the database the backend workers don't have access to this and won't be able to connect to the database.

I've also added the AWS and email secrets to both containers so the workers can also send emails and/or access file storage.