### PR TITLE
fix(kutt): add missing .auth level to postgres secret.yaml

### DIFF
--- a/charts/kutt/Chart.yaml
+++ b/charts/kutt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kutt
 description: Kutt is a free modern URL shortener.
 type: application
-version: 3.2.0
+version: 3.2.4
 appVersion: "v2.7.4"
 home: https://github.com/christianknell/helm-charts
 icon: https://www.saashub.com/images/app/service_logos/15/d634f2359578/large.png
@@ -22,8 +22,8 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: bumped dependency of redis to chart 18.1.1
+    - kind: fixed
+      description: missing .auth level in postgresql secret
   artifacthub.io/screenshots: |
     - title: Simply shorten your link using the Web UI.
       url: https://d4.alternativeto.net/v9sHosD3RiPblfBOOHZi0gwU1M0pRL6Jn53oiobJi9k/rs:fit:1200:1200:0/g:ce:0:0/YWJzOi8vZGlzdC9zL2t1dHQtaXRfNzY3MjMzX2Z1bGwucG5n.jpg

--- a/charts/kutt/templates/postgresql/secret.yaml
+++ b/charts/kutt/templates/postgresql/secret.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     {{- include "kutt.labels" . | nindent 4 }}
 data:
-  {{- include "kutt.postgresql.userPasswordKey" . | nindent 2 }}: {{ .Values.externalPostgresql.password | b64enc }}
+  {{- include "kutt.postgresql.userPasswordKey" . | nindent 2 }}: {{ .Values.externalPostgresql.auth.password | b64enc }}
 {{- end }}


### PR DESCRIPTION
Following the pattern in `README.md` for `externalPostgresql` and `externalPostgresql`:
https://github.com/christianknell/helm-charts/tree/main/charts/kutt#:~:text=externalPostgresql.auth.password
https://github.com/christianknell/helm-charts/tree/main/charts/kutt#:~:text=externalRedis.auth.password

https://github.com/christianknell/helm-charts/blame/5a9b896a800f4c8781645463639f60651878d4c3/charts/kutt/README.md#L56-L63