### PR TITLE
Add missing SHARED_SECRET env var + entry in /etc/hosts for reverse proxy

### DIFF
--- a/charts/headwind-mdm/templates/deployment.yaml
+++ b/charts/headwind-mdm/templates/deployment.yaml
@@ -26,6 +26,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "headwind-mdm.serviceAccountName" . }}
+      {{- if .Values.ingress.enabled }}
+      # Add entry in /etc/hosts to resolve public uri behind reverse proxy
+      hostAliases:
+        - ip:  {{ .Values.ingress.ip | quote }}
+          hostnames:
+          - {{ .Values.headwind.baseDomain | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -68,6 +75,10 @@ spec:
               value: "false"
             - name: INSTALL_LANGUAGE
               value: {{ .Values.headwind.installLanguage | default "en" | quote }}
+            {{ if .Values.headwind.sharedSecret -}}
+            - name: SHARED_SECRET
+              value: {{ .Values.headwind.sharedSecret | quote }}
+            {{ end -}}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Add missing SHARED_SECRET env var for premium deployment using headwindmdm/hmdm docker image.

Add hostAliases mapping when ingress is enabled to resolve uri on baseDomain to the reverse proxy ip as documented here: https://qa.h-mdm.com/1/installed-the-system-but-qr-code-is-not-showing

With these two changes, I am able to deploy on an existing AKS cluster.